### PR TITLE
update rover dev command to remove router version

### DIFF
--- a/rover-dev.md
+++ b/rover-dev.md
@@ -3,13 +3,11 @@
 ```sh
 APOLLO_KEY="..." \
 APOLLO_GRAPH_REF="..." \
-APOLLO_ROVER_DEV_ROUTER_VERSION="2.0.0" \
 rover dev --supergraph-config supergraph.yaml --router-config router-config.yaml
 ```
 
 ```powershell
 $env:APOLLO_KEY="..."
 $env:APOLLO_GRAPH_REF="..."
-$env:APOLLO_ROVER_DEV_ROUTER_VERSION="2.0.0"
 rover dev --supergraph-config supergraph.yaml --router-config router-config.yaml
 ```


### PR DESCRIPTION
Rover 0.28 now uses Router 2.0 by default